### PR TITLE
Updated min CPU to 4 for all nodes, removed RHEL 7.3 support. Closes #20

### DIFF
--- a/docs/bb0.adoc
+++ b/docs/bb0.adoc
@@ -4,7 +4,7 @@ before attempting to install Red Hat OpenShift.
 
 While running this *Building Block* the following technical prerequisites will be verified
 
-* each system having at least 2 CPU-Cores ( physical or virtual )
+* each system having at least 4 CPU-Cores ( physical or virtual )
 * each system having at least 16GB RAM
 * each system having at least 20GB of Disk Storage under /
 * each system having at least 40GB of Disk Storage under /var

--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -5,7 +5,7 @@ file_ip_data: ../ip
 sku_name: Employee SKU
 disk_free_space: 20
 node_mem: 16384
-node_vcpus: 2
+node_vcpus: 4
 sizing: fixed
 bandwidth_limit: 1
 ocp_version: "3.10"

--- a/playbooks/roles/check_os/tasks/main.yml
+++ b/playbooks/roles/check_os/tasks/main.yml
@@ -1,6 +1,5 @@
 - assert:
     that:
-      - (ansible_distribution == 'RedHat' and ansible_distribution_version == '7.3') or
-        (ansible_distribution == 'RedHat' and ansible_distribution_version == '7.4') or
+      - (ansible_distribution == 'RedHat' and ansible_distribution_version == '7.4') or
         (ansible_distribution == 'RedHat' and ansible_distribution_version == '7.5')
-    msg: "The only supported platforms for this release are RHEL 7.3 or RHEL 7.4 or RHEL 7.5"
+    msg: "The only supported platforms for this release are RHEL 7.4 or RHEL 7.5"

--- a/setup.sh
+++ b/setup.sh
@@ -24,11 +24,6 @@ if [ ! -f env.yml ]; then
     echo
 
 
-    echo "Are Hardware Requirements satisfied? Min. 16 GB RAM and 2 CPU"
-    echo "[y] n"
-    read req
-    [[ $req == "n" ]] && sed -Ei 's/sizing: (.*)/sizing: relaxed/' playbooks/group_vars/all
-
     echo "Please select OCP Version to install: 3.10, 3.9"
     echo "[3.10] 3.9"
     read ocp_version


### PR DESCRIPTION
- Updated min cpu to 4 for all nodes, because it is requested from 3.10 for masters
- Removed RHEL 7.3 support for 3.9 (we're going to deprecate also 3.9 when 3.11 will be released)
- Removed hw sizing question in setup.sh installer