### PR TITLE
Refactoring no_proxy generation, fixes #25

### DIFF
--- a/playbooks/roles/check_proxy/tasks/main.yml
+++ b/playbooks/roles/check_proxy/tasks/main.yml
@@ -16,6 +16,12 @@
   - "{{ proxy_uc_envs }}"
   - "{{ proxies }}"
   when: proxy_username is not defined and proxy_http is defined
+- name: ensure no proxy settings uppercase
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    line: "NO_PROXY=127.0.0.1,localhost,.svc,{{proxy_no | default('')}}"
+  when: proxy_http is defined
 - name: ensure proxy settings lowercase with username and password
   lineinfile:
     dest: /etc/environment
@@ -34,6 +40,12 @@
   - "{{ proxy_lc_envs }}"
   - "{{ proxies }}"
   when: proxy_username is not defined and proxy_http is defined
+- name: ensure no proxy settings lowercase
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    line: "no_proxy=127.0.0.1,localhost,.svc,{{proxy_no | default('')}}"
+  when: proxy_http is defined
 
 
 

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -6,15 +6,12 @@
     proxy_uc_envs:
     - HTTP_PROXY
     - HTTPS_PROXY
-    - NO_PROXY
     proxy_lc_envs:
     - http_proxy
     - https_proxy
-    - no_proxy
     proxies:
     - "{{ proxy_http }}"
     - "{{ proxy_https }}"
-    - "{{ proxy_no }}"
   vars_files:
   - "{{file_env}}"
   - "{{file_secrets}}"

--- a/setup.sh
+++ b/setup.sh
@@ -188,8 +188,8 @@ if [ ! -f env.yml ]; then
         done
 
         echo "proxy_https: $proxy_https" >> env.yml
-
-        echo "Please insert No Proxy (leave blank if any)"
+        
+        echo "Please insert No Proxy (leave blank if any, automatically adding localhost,127.0.0.1,.svc"
         read -r proxy_no
 
         if [ -n "$proxy_no" ]; then


### PR DESCRIPTION
Refactored no_proxy generation in /etc/environment to include always 

127.0.0.1,localhost,.svc

