### PR TITLE
Reset some services before checkup in bb0 - validate.yml

### DIFF
--- a/playbooks/reset_services.yml
+++ b/playbooks/reset_services.yml
@@ -1,0 +1,53 @@
+- name: Reset some services
+  hosts: all
+  gather_facts: no
+  vars_files:
+  - "{{file_env}}"
+  tasks:
+  - name: Flush iptables                                                                                               
+    iptables:                                                                                                          
+      flush: yes                                                                                                       
+ 
+  - name: Make sure firewalld is stopped                                                                               
+    service:                                                                                                           
+      name: firewalld                                                                                                  
+      enabled: false                                                                                                   
+      state: stopped                                                                                                   
+ 
+  - name: Start iptables service                                                                                       
+    service:                                                                                                           
+      name: iptables                                                                                                   
+      enabled: true                                                                                                    
+      state: started
+ 
+  - name: Uninstall chrony
+    yum:
+      name: chrony
+      state: absent
+ 
+  - name: Add iptables NTP INPUT
+    iptables:
+      chain: INPUT
+      protocol: udp
+      destination_port: 123
+      jump: ACCEPT
+      comment: "Accept NTP traffic"
+ 
+  - name: Add iptables NTP OUTPUT
+    iptables:
+      chain: OUTPUT
+      protocol: udp
+      source_port: 123
+      jump: ACCEPT
+      comment: "Accept NTP traffic"
+     
+  - name: Set NTP
+    shell: timedatectl set-ntp yes
+    async: 1
+    poll: 0
+ 
+  - name: Restart NTP service
+    service:
+      name: ntpd
+      state: restarted
+      enabled: yes

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -46,6 +46,7 @@
   - check_networking
   - check_packages_nodes
 
+- import_playbook: reset_services.yml
 
 - name: Validate environment
   gather_facts: no


### PR DESCRIPTION
This new yaml file (reset_services.yml) uninstall chrony and firewalld and flush/set iptables and set NTP as default. It is called in validate.yml before the 'Validate environment'.

Let me know what you think about it. Not sure if it is the best way but it does work by us (LV1871).

This could be added as correction to #1 .