### PR TITLE
Fixed Issue #78 - GlusterFS Check for specified container versions fails

### DIFF
--- a/playbooks/templates/hosts-v3.11.j2
+++ b/playbooks/templates/hosts-v3.11.j2
@@ -107,8 +107,14 @@ openshift_storage_glusterfs_name=ocs
 openshift_storage_glusterfs_wipe=True
 openshift_storage_glusterfs_storageclass=true
 openshift_storage_glusterfs_storageclass_default=true
-openshift_storage_glusterfs_image=registry.access.redhat.com/rhgs3/rhgs-server-rhel7
-openshift_storage_glusterfs_heketi_image=registry.access.redhat.com/rhgs3/rhgs-volmanager-rhel7
+
+# Fix for: https://access.redhat.com/solutions/3949971
+openshift_storage_glusterfs_image=registry.redhat.io/rhgs3/rhgs-server-rhel7:v3.11
+openshift_storage_glusterfs_block_image=registry.redhat.io/rhgs3/rhgs-gluster-block-prov-rhel7:v3.11
+openshift_storage_glusterfs_heketi_image=registry.redhat.io/rhgs3/rhgs-volmanager-rhel7:v3.11
+#openshift_storage_glusterfs_image=registry.access.redhat.com/rhgs3/rhgs-server-rhel7
+#openshift_storage_glusterfs_heketi_image=registry.access.redhat.com/rhgs3/rhgs-volmanager-rhel7
+
 openshift_storage_glusterfs_block_deploy=True
 openshift_storage_glusterfs_block_host_vol_create=true
 openshift_storage_glusterfs_block_host_vol_size=50


### PR DESCRIPTION
Fix for Issue #78 - https://access.redhat.com/solutions/3949971
```
TASK [openshift_storage_glusterfs : Check for specified container versions] ********************************************************************************************
task path: /usr/share/ansible/openshift-ansible/roles/openshift_storage_glusterfs/tasks/version_check.yml:2
Thursday 28 February 2019  17:43:55 +0100 (0:00:00.338)       0:22:58.357 ***** 
fatal: [upt-e2mastv-001.mev.atos.net]: FAILED! => {
    "changed": false, 
    "msg": "A valid version tag must be specified for all GlusterFS container images.\nValid image tags take the form of \"v3.x\" where \"x\" can be a one or two release\nversions (e.g. \"v3.0\" or \"v3.0.1\"). The following image versions were detected:\n\nGlusterFS: latest\nHeketi: latest\nglusterblock-provisioner: latest\n"
}
```